### PR TITLE
Implement custom type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,12 +47,10 @@
   "devDependencies": {
     "husky": "^4.2.5",
     "import-sort-style-module": "^6.0.0",
+    "prettier": "^2.0.5",
     "prettier-plugin-import-sort": "^0.0.4",
     "tsdx": "^0.13.2",
     "tslib": "^2.0.0",
     "typescript": "^3.9.6"
-  },
-  "dependencies": {
-    "@sindresorhus/is": "^3.0.0"
   }
 }

--- a/src/annotator.ts
+++ b/src/annotator.ts
@@ -1,5 +1,4 @@
-import is from '@sindresorhus/is';
-
+import { isMap } from './is';
 import { mapDeep } from './mapDeep';
 import {
   StringifiedPath,
@@ -49,7 +48,7 @@ export const makeAnnotator = () => {
   const annotations: Annotations = {};
 
   const annotator: Walker = ({ path, node }) => {
-    if (is.map(node)) {
+    if (isMap(node)) {
       const newNode = new Map<string, any>();
 
       for (const [key, value] of node.entries()) {
@@ -102,7 +101,7 @@ export const applyAnnotations = (plain: any, annotations: Annotations): any => {
     );
 
     for (const [path, type] of annotationsWithPathsLeavesToRoot) {
-      plain = mapDeep(plain, path, v =>
+      plain = mapDeep(plain, path, (v) =>
         untransformValue(v, type as TypeAnnotation)
       );
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
-import is from '@sindresorhus/is';
-
 import { applyAnnotations, makeAnnotator } from './annotator';
+import { isEmptyObject } from './is';
 import { plainer } from './plainer';
 import { SuperJSONResult, SuperJSONValue, isSuperJSONResult } from './types';
 
@@ -10,7 +9,7 @@ export const serialize = (object: SuperJSONValue): SuperJSONResult => {
 
   return {
     json: output,
-    meta: is.emptyObject(annotations) ? undefined : annotations,
+    meta: isEmptyObject(annotations) ? undefined : annotations,
   };
 };
 

--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -1,0 +1,69 @@
+import {
+  isArray,
+  isBoolean,
+  isDate,
+  isNull,
+  isNumber,
+  isPrimitive,
+  isRegExp,
+  isString,
+  isSymbol,
+  isUndefined,
+} from './is';
+
+test('Basic true tests', () => {
+  expect(isUndefined(undefined)).toBe(true);
+  expect(isNull(null)).toBe(true);
+
+  expect(isArray([])).toBe(true);
+  expect(isArray(new Array())).toBe(true);
+  expect(isString('')).toBe(true);
+  expect(isString('_')).toBe(true);
+
+  expect(isBoolean(true)).toBe(true);
+  expect(isBoolean(false)).toBe(true);
+  expect(isRegExp(/./)).toBe(true);
+  expect(isRegExp(/./gi)).toBe(true);
+  expect(isNumber(0)).toBe(true);
+  expect(isNumber(1)).toBe(true);
+  expect(isDate(new Date())).toBe(true);
+  expect(isSymbol(Symbol())).toBe(true);
+});
+
+test('Basic false tests', () => {
+  expect(isNumber(NaN)).toBe(false);
+  expect(isDate(new Date('_'))).toBe(false);
+  expect(isDate(NaN)).toBe(false);
+  expect(isUndefined(NaN)).toBe(false);
+  expect(isNull(NaN)).toBe(false);
+
+  expect(isArray(NaN)).toBe(false);
+  expect(isString(NaN)).toBe(false);
+
+  expect(isBoolean(NaN)).toBe(false);
+  expect(isRegExp(NaN)).toBe(false);
+  expect(isSymbol(NaN)).toBe(false);
+});
+
+test('Primitive tests', () => {
+  expect(isPrimitive(0)).toBe(true);
+  expect(isPrimitive('')).toBe(true);
+  expect(isPrimitive('str')).toBe(true);
+  expect(isPrimitive(Symbol())).toBe(true);
+  expect(isPrimitive(true)).toBe(true);
+  expect(isPrimitive(false)).toBe(true);
+  expect(isPrimitive(null)).toBe(true);
+  expect(isPrimitive(undefined)).toBe(true);
+
+  expect(isPrimitive(NaN)).toBe(false);
+  expect(isPrimitive([])).toBe(false);
+  expect(isPrimitive(new Array())).toBe(false);
+  expect(isPrimitive({})).toBe(false);
+  expect(isPrimitive(new Object())).toBe(false);
+  expect(isPrimitive(new Date())).toBe(false);
+  expect(isPrimitive(() => {})).toBe(false);
+});
+
+test('Date exception', () => {
+  expect(isDate(new Date('_'))).toBe(false);
+});

--- a/src/is.ts
+++ b/src/is.ts
@@ -1,0 +1,67 @@
+const getType = (payload: any): string =>
+  Object.prototype.toString.call(payload).slice(8, -1);
+
+export const isUndefined = (payload: any): payload is undefined =>
+  getType(payload) === 'Undefined';
+
+export const isNull = (payload: any): payload is null =>
+  getType(payload) === 'Null';
+
+export const isPlainObject = (
+  payload: any
+): payload is { [key: string]: any } => {
+  if (getType(payload) !== 'Object') return false;
+  return (
+    payload.constructor === Object &&
+    Object.getPrototypeOf(payload) === Object.prototype
+  );
+};
+
+export const isEmptyObject = (payload: any): payload is {} =>
+  isPlainObject(payload) && Object.keys(payload).length === 0;
+
+export const isArray = (payload: any): payload is any[] =>
+  getType(payload) === 'Array';
+
+export const isString = (payload: any): payload is string =>
+  getType(payload) === 'String';
+
+export const isNumber = (payload: any): payload is number =>
+  getType(payload) === 'Number' && !isNaN(payload);
+
+export const isBoolean = (payload: any): payload is boolean =>
+  getType(payload) === 'Boolean';
+
+export const isRegExp = (payload: any): payload is RegExp =>
+  getType(payload) === 'RegExp';
+
+export const isMap = (payload: any): payload is Map<any, any> =>
+  getType(payload) === 'Map';
+
+export const isSet = (payload: any): payload is Set<any> =>
+  getType(payload) === 'Set';
+
+export const isSymbol = (payload: any): payload is symbol =>
+  getType(payload) === 'Symbol';
+
+export const isDate = (payload: any): payload is Date =>
+  getType(payload) === 'Date' && !isNaN(payload);
+
+export const isNaNValue = (payload: any): payload is typeof NaN =>
+  getType(payload) === 'Number' && isNaN(payload);
+
+export const isPrimitive = (
+  payload: any
+): payload is boolean | null | undefined | number | string | symbol =>
+  isBoolean(payload) ||
+  isNull(payload) ||
+  isUndefined(payload) ||
+  isNumber(payload) ||
+  isString(payload) ||
+  isSymbol(payload);
+
+export const isBigint = (payload: any): payload is bigint =>
+  getType(payload) === 'BigInt';
+
+export const isInfinite = (payload: any): payload is number =>
+  payload === Infinity || payload === -Infinity;

--- a/src/mapDeep.ts
+++ b/src/mapDeep.ts
@@ -1,4 +1,4 @@
-import is from '@sindresorhus/is';
+import { isArray } from './is';
 
 export const mapDeep = (
   object: object,
@@ -11,7 +11,7 @@ export const mapDeep = (
 
   const [head, ...tail] = path;
 
-  if (is.array(object)) {
+  if (isArray(object)) {
     return object.map((v, i) => {
       if (i === head) {
         return mapDeep(v, tail, mapper);

--- a/src/pathstringifier.ts
+++ b/src/pathstringifier.ts
@@ -5,10 +5,7 @@ const escape = (key: string) => key.replace(/\./g, '\\.');
 const unescape = (k: string) => k.replace(/\\\./g, '.');
 
 export const stringifyPath = (path: Path): StringifiedPath =>
-  path
-    .map(String)
-    .map(escape)
-    .join('.');
+  path.map(String).map(escape).join('.');
 
 export const parsePath = (string: StringifiedPath): Path =>
   string.split(/(?<!\\)\./g).map(unescape);

--- a/src/plainer.ts
+++ b/src/plainer.ts
@@ -1,4 +1,4 @@
-import is from '@sindresorhus/is';
+import { isArray, isMap, isPlainObject, isPrimitive, isSet } from './is';
 
 interface WalkerValue {
   isLeaf: boolean;
@@ -9,17 +9,14 @@ interface WalkerValue {
 export type Walker = (v: WalkerValue) => any;
 
 const isDeep = (object: any): boolean =>
-  is.plainObject(object) ||
-  is.array(object) ||
-  is.map(object) ||
-  is.set(object);
+  isPlainObject(object) || isArray(object) || isMap(object) || isSet(object);
 
 const entries = (object: object | Map<any, any>): [any, any][] => {
-  if (is.map(object)) {
+  if (isMap(object)) {
     return [...object.entries()];
   }
 
-  if (is.plainObject(object)) {
+  if (isPlainObject(object)) {
     return Object.entries(object);
   }
 
@@ -40,19 +37,19 @@ export const plainer = (
     throw new TypeError('Circular Reference');
   }
 
-  if (!is.primitive(object)) {
+  if (!isPrimitive(object)) {
     alreadySeenObjects.add(object);
   }
 
   walker({ isLeaf: false, path, node: object });
 
-  if (is.array(object) || is.set(object)) {
+  if (isArray(object) || isSet(object)) {
     return [...object].map((value, key) =>
       plainer(value, walker, [...path, key], alreadySeenObjects)
     );
   }
 
-  if (is.plainObject(object) || is.map(object)) {
+  if (isPlainObject(object) || isMap(object)) {
     return Object.fromEntries(
       entries(object).map(([key, value]) => [
         key,

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,4 +1,15 @@
-import is from '@sindresorhus/is';
+import {
+  isBigint,
+  isBoolean,
+  isDate,
+  isInfinite,
+  isMap,
+  isNaNValue,
+  isNumber,
+  isRegExp,
+  isSet,
+  isUndefined,
+} from './is';
 
 export type PrimitiveTypeAnnotation =
   | 'NaN'
@@ -38,42 +49,42 @@ export const isTypeAnnotation = (value: any): value is TypeAnnotation => {
 export const transformValue = (
   value: any
 ): { value: any; type: TypeAnnotation } | undefined => {
-  if (is.undefined(value)) {
+  if (isUndefined(value)) {
     return {
       value: undefined,
       type: 'undefined',
     };
-  } else if (is.bigint(value)) {
+  } else if (isBigint(value)) {
     return {
       value: value.toString(),
       type: 'bigint',
     };
-  } else if (is.date(value)) {
+  } else if (isDate(value)) {
     return {
       value: value.toISOString(),
       type: 'Date',
     };
-  } else if (is.nan(value)) {
+  } else if (isNaNValue(value)) {
     return {
       value: undefined,
       type: 'NaN',
     };
-  } else if (is.infinite(value)) {
+  } else if (isInfinite(value)) {
     return {
       value: undefined,
       type: value > 0 ? 'Infinity' : '-Infinity',
     };
-  } else if (is.set(value)) {
+  } else if (isSet(value)) {
     return {
       value: Array.from(value) as any[],
       type: 'set',
     };
-  } else if (is.regExp(value)) {
+  } else if (isRegExp(value)) {
     return {
       value: '' + value,
       type: 'regexp',
     };
-  } else if (is.map(value)) {
+  } else if (isMap(value)) {
     return {
       value: value,
       type: 'map',
@@ -127,11 +138,11 @@ export function isKeyTypeAnnotation(
 export function transformKey(
   key: any
 ): { key: string; type: KeyTypeAnnotation } | undefined {
-  if (is.number(key)) {
+  if (isNumber(key)) {
     return { key: '' + key, type: 'number' };
   }
 
-  if (is.boolean(key)) {
+  if (isBoolean(key)) {
     return { key: '' + key, type: 'boolean' };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
-import is from '@sindresorhus/is';
-
 import { Annotations, isAnnotations } from './annotator';
+import { isUndefined } from './is';
 
 export type PrimitveJSONValue = string | number | boolean | undefined | null;
 
@@ -45,11 +44,11 @@ export interface SuperJSONResult {
 }
 
 export function isSuperJSONResult(object: any): object is SuperJSONResult {
-  if (is.undefined(object.json)) {
+  if (isUndefined(object.json)) {
     return false;
   }
 
-  if (is.undefined(object.meta)) {
+  if (isUndefined(object.meta)) {
     return true;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,11 +1092,6 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@sindresorhus/is@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-3.0.0.tgz#78fabc5e295adb6e1ef57eaafe4cc5d7aa35b183"
-  integrity sha512-kqA5I6Yun7PBHk8WN9BBP1c7FfN2SrD05GuVSEYPqDb4nerv7HqYfgBfMIKmT/EuejURkJKLZuLyGKGs6WEG9w==
-
 "@types/babel__core@^7.1.0":
   version "7.1.9"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.9.tgz#77e59d438522a6fb898fa43dc3455c6e72f3963d"
@@ -4780,6 +4775,11 @@ prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-format@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
It turns out that `@sindresorhus/is` is actually quite big! Right now it accounts for 64% of our [bundle size](https://bundlephobia.com/result?p=superjson@1.0.1). This is because it provides much more functionality than we actually need–we only use a handful of `is.whatever` functions. I’ve therefore written a custom type-checking util which should be much more lightweight. This also means we can brag about having zero external dependencies 😄.