### PR TITLE
Upgrade actions/cache to v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
           node-version: 12.x
 
       - name: Use cached node_modules
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: node_modules
           key: nodeModules-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
[actions/cache@2](https://github.com/actions/cache/releases/tag/v2.0.0) has been released and comes with some useful updates.
