### PR TITLE
Revive classes

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,5 +1,5 @@
 const Benchmark = require("benchmark")
-const SuperJSON = require("./dist/")
+const SuperJSON = require("./dist/").default
 
 const instances = {
     "toy example": {

--- a/src/class-registry.test.ts
+++ b/src/class-registry.test.ts
@@ -1,0 +1,35 @@
+import * as ClassRegistry from './class-registry';
+
+test('class registry', () => {
+  class Car {
+    honk() {
+      console.log('honk');
+    }
+  }
+  ClassRegistry.registerClass(Car);
+
+  expect(ClassRegistry.getClass('Car')).toBe(Car);
+  expect(ClassRegistry.getIdentifier(Car)).toBe('Car');
+
+  expect(() => ClassRegistry.registerClass(Car)).not.toThrow();
+
+  expect(() => ClassRegistry.registerClass(class Car {})).toThrow(
+    'Ambiguous class, provide a unique identifier.'
+  );
+
+  ClassRegistry.unregisterClass(Car);
+
+  expect(ClassRegistry.getClass('Car')).toBeUndefined();
+
+  ClassRegistry.registerClass(Car, 'car1');
+
+  ClassRegistry.registerClass(class Car {}, 'car2');
+
+  expect(ClassRegistry.getClass('car1')).toBe(Car);
+
+  expect(ClassRegistry.getClass('car2')).not.toBeUndefined();
+
+  ClassRegistry.clear();
+
+  expect(ClassRegistry.getClass('car1')).toBeUndefined();
+});

--- a/src/class-registry.ts
+++ b/src/class-registry.ts
@@ -1,3 +1,5 @@
+import { Class } from './types';
+
 class DoubleIndexedKV<K, V> {
   keyToValue = new Map<K, V>();
   valueToKey = new Map<V, K>();
@@ -29,8 +31,6 @@ class DoubleIndexedKV<K, V> {
     this.valueToKey.clear();
   }
 }
-
-type Class = { new (): any };
 
 const classRegistry = new DoubleIndexedKV<string, Class>();
 

--- a/src/class-registry.ts
+++ b/src/class-registry.ts
@@ -1,0 +1,67 @@
+class DoubleIndexedKV<K, V> {
+  keyToValue = new Map<K, V>();
+  valueToKey = new Map<V, K>();
+
+  set(key: K, value: V) {
+    this.keyToValue.set(key, value);
+    this.valueToKey.set(value, key);
+  }
+
+  deleteByValue(value: V) {
+    this.valueToKey.delete(value);
+    this.keyToValue.forEach((otherValue, otherKey) => {
+      if (value === otherValue) {
+        this.keyToValue.delete(otherKey);
+      }
+    });
+  }
+
+  getByKey(key: K): V | undefined {
+    return this.keyToValue.get(key);
+  }
+
+  getByValue(value: V): K | undefined {
+    return this.valueToKey.get(value);
+  }
+
+  clear() {
+    this.keyToValue.clear();
+    this.valueToKey.clear();
+  }
+}
+
+type Class = { new (): any };
+
+const classRegistry = new DoubleIndexedKV<string, Class>();
+
+export function registerClass(clazz: Class, identifier?: string): void {
+  if (classRegistry.getByValue(clazz)) {
+    return;
+  }
+
+  if (!identifier) {
+    identifier = clazz.name;
+  }
+
+  if (classRegistry.getByKey(identifier)) {
+    throw new Error('Ambiguous class, provide a unique identifier.');
+  }
+
+  classRegistry.set(identifier, clazz);
+}
+
+export function unregisterClass(clazz: Class): void {
+  classRegistry.deleteByValue(clazz);
+}
+
+export function clear(): void {
+  classRegistry.clear();
+}
+
+export function getIdentifier(clazz: Class) {
+  return classRegistry.getByValue(clazz);
+}
+
+export function getClass(identifier: string) {
+  return classRegistry.getByKey(identifier);
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -460,7 +460,7 @@ describe('stringify & parse', () => {
       SuperJSON.registerClass(Train);
 
       const { json, meta } = SuperJSON.serialize({
-        s7: new Train(100, 'yellow', 'Bombardier') as any,
+        s7: new Train(100, 'yellow', 'Bombardier'),
       });
 
       expect(json).toEqual({
@@ -497,7 +497,7 @@ describe('stringify & parse', () => {
         SuperJSON.registerClass(Currency);
 
         const { json, meta } = SuperJSON.serialize({
-          price: new Currency(100) as any,
+          price: new Currency(100),
         });
 
         expect(json).toEqual({

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -374,6 +374,36 @@ describe('stringify & parse', () => {
       expect(deserialized.s7).toBeInstanceOf(Train);
       expect(typeof deserialized.s7.brag()).toBe('string');
     });
+
+    describe('with accessor attributes', () => {
+      it('works', () => {
+        class Currency {
+          constructor(private valueInUsd: number) {}
+
+          get inUSD() {
+            return this.valueInUsd;
+          }
+        }
+
+        SuperJSON.registerClass(Currency);
+
+        const { json, meta } = SuperJSON.serialize({
+          price: new Currency(100) as any, // typing is to be solved
+        });
+
+        expect(json).toEqual({
+          price: {
+            valueInUsd: 100,
+          },
+        });
+
+        const result: any = SuperJSON.parse(JSON.stringify({ json, meta }));
+
+        const price: Currency = result.price;
+
+        expect(price.inUSD).toBe(100);
+      });
+    });
   });
 
   describe('when given a non-SuperJSON object', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -100,9 +100,9 @@ describe('stringify & parse', () => {
 
       outputAnnotations: {
         values: {
-          a: 'map:number',
-          b: 'map:string',
-          d: 'map:boolean',
+          a: ['map', 'number'],
+          b: ['map', 'string'],
+          d: ['map', 'boolean'],
         },
       },
     },
@@ -362,7 +362,11 @@ describe('stringify & parse', () => {
         },
       });
 
-      expect(meta).toEqual({});
+      expect(meta).toEqual({
+        values: {
+          s7: ['class', 'Train'],
+        },
+      });
 
       const deserialized: any = SuperJSON.deserialize(
         JSON.parse(JSON.stringify({ json, meta }))

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -351,7 +351,7 @@ describe('stringify & parse', () => {
       SuperJSON.registerClass(Train);
 
       const { json, meta } = SuperJSON.serialize({
-        s7: new Train(100, 'yellow', 'Bombardier') as any, // typing is to be solved
+        s7: new Train(100, 'yellow', 'Bombardier'),
       });
 
       expect(json).toEqual({
@@ -388,7 +388,7 @@ describe('stringify & parse', () => {
         SuperJSON.registerClass(Currency);
 
         const { json, meta } = SuperJSON.serialize({
-          price: new Currency(100) as any, // typing is to be solved
+          price: new Currency(100),
         });
 
         expect(json).toEqual({

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import * as SuperJSON from './';
+import SuperJSON from './';
 import { Annotations } from './annotator';
 import { isArray, isMap, isPlainObject, isPrimitive, isSet } from './is';
 import { JSONValue, SuperJSONValue } from './types';

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -334,6 +334,44 @@ describe('stringify & parse', () => {
     });
   }
 
+  describe('when serializing custom class instances', () => {
+    it('revives them to their original class', () => {
+      class Train {
+        constructor(
+          private topSpeed: number,
+          private color: 'red' | 'blue' | 'yellow',
+          private brand: string
+        ) {}
+
+        public brag() {
+          return `I'm a ${this.brand} in freakin' ${this.color} and I go ${this.topSpeed} km/h, isn't that bonkers?`;
+        }
+      }
+
+      SuperJSON.registerClass(Train);
+
+      const { json, meta } = SuperJSON.serialize({
+        s7: new Train(100, 'yellow', 'Bombardier') as any, // typing is to be solved
+      });
+
+      expect(json).toEqual({
+        s7: {
+          topSpeed: 100,
+          color: 'yellow',
+          brand: 'Bombardier',
+        },
+      });
+
+      expect(meta).toEqual({});
+
+      const deserialized: any = SuperJSON.deserialize(
+        JSON.parse(JSON.stringify({ json, meta }))
+      );
+      expect(deserialized.s7).toBeInstanceOf(Train);
+      expect(typeof deserialized.s7.brag()).toBe('string');
+    });
+  });
+
   describe('when given a non-SuperJSON object', () => {
     it('throws', () => {
       expect(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,9 @@ import { applyAnnotations, makeAnnotator } from './annotator';
 import { isEmptyObject } from './is';
 import { plainer } from './plainer';
 import { SuperJSONResult, SuperJSONValue, isSuperJSONResult } from './types';
+import { clear, registerClass, unregisterClass } from './class-registry';
 
-export const serialize = (object: SuperJSONValue): SuperJSONResult => {
+const serialize = (object: SuperJSONValue): SuperJSONResult => {
   const { getAnnotations, annotator } = makeAnnotator();
   const output = plainer(object, annotator);
 
@@ -15,7 +16,7 @@ export const serialize = (object: SuperJSONValue): SuperJSONResult => {
   };
 };
 
-export const deserialize = (payload: SuperJSONResult): SuperJSONValue => {
+const deserialize = (payload: SuperJSONResult): SuperJSONValue => {
   if (!isSuperJSONResult(payload)) {
     throw new Error('Not a valid SuperJSON payload.');
   }
@@ -29,10 +30,18 @@ export const deserialize = (payload: SuperJSONResult): SuperJSONValue => {
   return json;
 };
 
-export const stringify = (object: SuperJSONValue): string =>
+const stringify = (object: SuperJSONValue): string =>
   JSON.stringify(serialize(object));
 
-export const parse = (string: string): SuperJSONValue =>
+const parse = (string: string): SuperJSONValue =>
   deserialize(JSON.parse(string));
 
-export default { stringify, parse, serialize, deserialize };
+export default {
+  stringify,
+  parse,
+  serialize,
+  deserialize,
+  clear,
+  registerClass,
+  unregisterClass,
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,12 +13,15 @@ export interface JSONObject {
   [key: string]: JSONValue;
 }
 
+type ClassInstance = any;
+
 export type SerializableJSONValue =
   | Set<SuperJSONValue>
   | Map<SuperJSONValue, SuperJSONValue>
   | undefined
   | bigint
   | Date
+  | ClassInstance
   | RegExp;
 
 export type SuperJSONValue =

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
 import { Annotations, isAnnotations } from './annotator';
 import { isUndefined } from './is';
 
+export type Class = { new (...args: any[]): any };
+
 export type PrimitveJSONValue = string | number | boolean | undefined | null;
 
 export type JSONValue = PrimitveJSONValue | JSONArray | JSONObject;


### PR DESCRIPTION
Closes #34 

Implements revival of ES6 classes by attaching the original prototypes during revival. It requires registering all neccessary classes using `SuperJSON.registerClass(...)`.
In the future, this could be done automatically in a compile-step (Which poses it's own issues, e.g. figuring out which classes are actually used and which classes to bundle therefore, but would make it opaque to Blitz users).