### PR TITLE
Fix export of `serialize`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
 import { ClassRegistry } from './class-registry';
 import { SymbolRegistry } from './symbol-registry';
 
-const serialize = (object: SuperJSONValue): SuperJSONResult => {
+export const serialize = (object: SuperJSONValue): SuperJSONResult => {
   const { getAnnotations, annotator } = makeAnnotator();
   const output = plainer(object, annotator);
 


### PR DESCRIPTION
Somehow this export got removed from the previous release which is a breaking change.