### PR TITLE
Add support for custom serialisers

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,9 +59,11 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.161",
+    "@types/mongodb": "^3.5.27",
     "benchmark": "^2.1.4",
     "eslint-plugin-es5": "^1.5.0",
     "husky": "^4.2.5",
+    "mongodb": "^3.6.2",
     "tsdx": "^0.13.2",
     "tslib": "^2.0.0",
     "typescript": "^3.9.6"

--- a/src/annotator.ts
+++ b/src/annotator.ts
@@ -148,7 +148,6 @@ export const applyAnnotations = (plain: any, annotations: Annotations): any => {
       PathTree.expandRoot(annotations.referentialEqualities),
       (identicalObjects, path) => {
         const object = getDeep(plain, path);
-        console.log(object);
 
         PathTree.traversePaths(
           PathTree.expandRoot(identicalObjects),

--- a/src/custom-transformer-registry.ts
+++ b/src/custom-transformer-registry.ts
@@ -1,0 +1,27 @@
+import { JSONValue } from './types';
+import _ from 'lodash';
+
+export interface CustomTransfomer<I, O extends JSONValue> {
+  name: string;
+  isApplicable: (v: any) => v is I;
+  serialize: (v: I) => O;
+  deserialize: (v: O) => I;
+}
+
+const transfomers: Record<string, CustomTransfomer<any, any>> = {};
+
+export const CustomTransformerRegistry = {
+  register<I, O extends JSONValue>(transformer: CustomTransfomer<I, O>) {
+    transfomers[transformer.name] = transformer;
+  },
+
+  findApplicable<T>(v: T) {
+    return _.find(transfomers, transformer => transformer.isApplicable(v)) as
+      | CustomTransfomer<T, JSONValue>
+      | undefined;
+  },
+
+  findByName(name: string) {
+    return transfomers[name];
+  },
+};

--- a/src/double-indexed-kv.ts
+++ b/src/double-indexed-kv.ts
@@ -7,15 +7,6 @@ export class DoubleIndexedKV<K, V> {
     this.valueToKey.set(value, key);
   }
 
-  deleteByValue(value: V) {
-    this.valueToKey.delete(value);
-    this.keyToValue.forEach((otherValue, otherKey) => {
-      if (value === otherValue) {
-        this.keyToValue.delete(otherKey);
-      }
-    });
-  }
-
   getByKey(key: K): V | undefined {
     return this.keyToValue.get(key);
   }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -6,6 +6,8 @@ import { JSONValue, SuperJSONValue } from './types';
 import { Annotations } from './annotator';
 import { isArray, isMap, isPlainObject, isPrimitive, isSet } from './is';
 
+import { ObjectID } from 'mongodb';
+
 describe('stringify & parse', () => {
   const cases: Record<
     string,
@@ -404,6 +406,31 @@ describe('stringify & parse', () => {
         values: {
           'a.role': [['symbol', '1']],
           'b.role': [['symbol', '2']],
+        },
+      },
+    },
+
+    'works for custom transformers': {
+      input: () => {
+        SuperJSON.registerCustom<ObjectID, string>(
+          {
+            isApplicable: (v): v is ObjectID => v instanceof ObjectID,
+            serialize: v => v.toHexString(),
+            deserialize: v => new ObjectID(v),
+          },
+          'objectid'
+        );
+
+        return {
+          a: new ObjectID('5f7887f4f0b172093e89f126'),
+        };
+      },
+      output: {
+        a: '5f7887f4f0b172093e89f126',
+      },
+      outputAnnotations: {
+        values: {
+          a: [['custom', 'objectid']],
         },
       },
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,14 @@ import {
   SuperJSONValue,
   isSuperJSONResult,
   Class,
+  JSONValue,
 } from './types';
 import { ClassRegistry } from './class-registry';
 import { SymbolRegistry } from './symbol-registry';
+import {
+  CustomTransfomer,
+  CustomTransformerRegistry,
+} from './custom-transformer-registry';
 
 export const serialize = (object: SuperJSONValue): SuperJSONResult => {
   const { getAnnotations, annotator } = makeAnnotator();
@@ -46,11 +51,18 @@ export const parse = <T = unknown>(string: string): T =>
 
 const registerClass = (v: Class, identifier?: string) =>
   ClassRegistry.register(v, identifier);
-const unregisterClass = (v: Class) => ClassRegistry.unregister(v);
 
 const registerSymbol = (v: Symbol, identifier?: string) =>
   SymbolRegistry.register(v, identifier);
-const unregisterSymbol = (v: Symbol) => SymbolRegistry.unregister(v);
+
+const registerCustom = <I, O extends JSONValue>(
+  transformer: Omit<CustomTransfomer<I, O>, 'name'>,
+  name: string
+) =>
+  CustomTransformerRegistry.register({
+    name,
+    ...transformer,
+  });
 
 export default {
   stringify,
@@ -58,7 +70,6 @@ export default {
   serialize,
   deserialize,
   registerClass,
-  unregisterClass,
   registerSymbol,
-  unregisterSymbol,
+  registerCustom,
 };

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -20,15 +20,7 @@ test('class registry', () => {
     'Ambiguous class, provide a unique identifier.'
   );
 
-  registry.unregister(Car);
-
-  expect(registry.getValue('Car')).toBeUndefined();
-
-  registry.register(Car, 'car1');
-
   registry.register(class Car {}, 'car2');
-
-  expect(registry.getValue('car1')).toBe(Car);
 
   expect(registry.getValue('car2')).not.toBeUndefined();
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -21,10 +21,6 @@ export class Registry<T> {
     this.kv.set(identifier, value);
   }
 
-  unregister(v: T): void {
-    this.kv.deleteByValue(v);
-  }
-
   clear(): void {
     this.kv.clear();
   }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -13,6 +13,7 @@ import {
 import { ClassRegistry } from './class-registry';
 import { SymbolRegistry } from './symbol-registry';
 import { fromPairs, includes, entries } from 'lodash';
+import { CustomTransformerRegistry } from './custom-transformer-registry';
 
 export type PrimitiveTypeAnnotation = 'number' | 'undefined' | 'bigint';
 
@@ -20,10 +21,14 @@ type LeafTypeAnnotation = PrimitiveTypeAnnotation | 'regexp' | 'Date';
 
 type ClassTypeAnnotation = ['class', string];
 type SymbolTypeAnnotation = ['symbol', string];
+type CustomTypeAnnotation = ['custom', string];
 
 type SimpleTypeAnnotation = LeafTypeAnnotation | 'map' | 'set';
 
-type CompositeTypeAnnotation = ClassTypeAnnotation | SymbolTypeAnnotation;
+type CompositeTypeAnnotation =
+  | ClassTypeAnnotation
+  | SymbolTypeAnnotation
+  | CustomTypeAnnotation;
 
 export type TypeAnnotation = SimpleTypeAnnotation | CompositeTypeAnnotation;
 
@@ -184,7 +189,28 @@ const classRule = compositeTransformation(
   }
 );
 
-const compositeRules = [classRule, symbolRule];
+const customRule = compositeTransformation(
+  (value): value is any => {
+    return !!CustomTransformerRegistry.findApplicable(value);
+  },
+  value => {
+    const transformer = CustomTransformerRegistry.findApplicable(value)!;
+    return ['custom', transformer.name];
+  },
+  value => {
+    const transformer = CustomTransformerRegistry.findApplicable(value)!;
+    return transformer.serialize(value);
+  },
+  (v, a) => {
+    const transformer = CustomTransformerRegistry.findByName(a[1]);
+    if (!transformer) {
+      throw new Error('Trying to deserialize unknown custom value');
+    }
+    return transformer.deserialize(v);
+  }
+);
+
+const compositeRules = [classRule, symbolRule, customRule];
 
 export const transformValue = (
   value: any
@@ -223,6 +249,8 @@ export const untransformValue = (json: any, type: TypeAnnotation) => {
         return symbolRule.untransform(json, type);
       case 'class':
         return classRule.untransform(json, type);
+      case 'custom':
+        return customRule.untransform(json, type);
       default:
         throw new Error('Unknown transformation: ' + type);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1052,6 +1052,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bson@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/bson/-/bson-4.0.2.tgz#7accb85942fc39bbdb7515d4de437c04f698115f"
+  integrity sha512-+uWmsejEHfmSjyyM/LkrP0orfE2m5Mx9Xel4tXNeqi1ldK5XMQcDsFkBmLDtuyKUbxj2jGDo0H240fbCRJZo7Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -1113,6 +1120,14 @@
   version "4.14.161"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.161.tgz#a21ca0777dabc6e4f44f3d07f37b765f54188b18"
   integrity sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==
+
+"@types/mongodb@^3.5.27":
+  version "3.5.27"
+  resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-3.5.27.tgz#158a7a43ce25ef3592ac8a62e62ab38bebf661f2"
+  integrity sha512-1jxKDgdfJEOO9zp+lv43p8jOqRs02xPrdUTzAZIVK9tVEySfCEmktL2jEu9A3wOBEOs18yKzpVIKUh8b8ALk3w==
+  dependencies:
+    "@types/bson" "*"
+    "@types/node" "*"
 
 "@types/node@*":
   version "14.0.14"
@@ -1617,6 +1632,14 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
+bl@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-2.2.1.tgz#8c11a7b730655c5d56898cdc871224f40fd901d5"
+  integrity sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==
+  dependencies:
+    readable-stream "^2.3.5"
+    safe-buffer "^5.1.1"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1676,6 +1699,11 @@ bser@2.1.1:
   integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
   dependencies:
     node-int64 "^0.4.0"
+
+bson@^1.1.4:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.5.tgz#2aaae98fcdf6750c0848b0cba1ddec3c73060a34"
+  integrity sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==
 
 buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
@@ -1942,7 +1970,7 @@ core-js@^2.4.0, core-js@^2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
-core-util-is@1.0.2:
+core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
@@ -2080,6 +2108,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+denque@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
+  integrity sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -2993,7 +3026,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3220,7 +3253,7 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-isarray@1.0.0, isarray@^1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -4011,6 +4044,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+memory-pager@^1.0.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/memory-pager/-/memory-pager-1.5.0.tgz#d8751655d22d384682741c972f2c3d6dfa3e66b5"
+  integrity sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -4083,6 +4121,19 @@ mkdirp@0.x, mkdirp@^0.5.1:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mongodb@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.6.2.tgz#1154a4ac107bf1375112d83a29c5cf97704e96b6"
+  integrity sha512-sSZOb04w3HcnrrXC82NEh/YGCmBuRgR+C1hZgmmv4L6dBz4BkRse6Y8/q/neXer9i95fKUBbFi4KgeceXmbsOA==
+  dependencies:
+    bl "^2.2.1"
+    bson "^1.1.4"
+    denque "^1.4.1"
+    require_optional "^1.0.1"
+    safe-buffer "^5.1.2"
+  optionalDependencies:
+    saslprep "^1.0.0"
 
 mri@^1.1.0:
   version "1.1.5"
@@ -4618,6 +4669,11 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
 progress-estimator@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/progress-estimator/-/progress-estimator-0.2.2.tgz#1c3947a5782ea56e40c8fccc290ac7ceeb1b91cb"
@@ -4711,6 +4767,19 @@ read-pkg@^3.0.0:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
+
+readable-stream@^2.3.5:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 realpath-native@^1.1.0:
   version "1.1.0"
@@ -4872,12 +4941,25 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+require_optional@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/require_optional/-/require_optional-1.0.1.tgz#4cf35a4247f64ca3df8c2ef208cc494b1ca8fc2e"
+  integrity sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==
+  dependencies:
+    resolve-from "^2.0.0"
+    semver "^5.1.0"
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
   integrity sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=
   dependencies:
     resolve-from "^3.0.0"
+
+resolve-from@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
+  integrity sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=
 
 resolve-from@^3.0.0:
   version "3.0.0"
@@ -5026,12 +5108,12 @@ sade@^1.4.2:
   dependencies:
     mri "^1.1.0"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.2:
+safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-safe-buffer@~5.1.1:
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -5063,6 +5145,13 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
+saslprep@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/saslprep/-/saslprep-1.0.3.tgz#4c02f946b56cf54297e347ba1093e7acac4cf226"
+  integrity sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==
+  dependencies:
+    sparse-bitfield "^3.0.3"
+
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -5078,7 +5167,7 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -5262,6 +5351,13 @@ sourcemap-codec@^1.4.4:
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
+sparse-bitfield@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz#ff4ae6e68656056ba4b3e792ab3334d38273ca11"
+  integrity sha1-/0rm5oZWBWuks+eSqzM004JzyhE=
+  dependencies:
+    memory-pager "^1.0.2"
+
 spdx-correct@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.1.tgz#dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9"
@@ -5402,6 +5498,13 @@ string.prototype.trimstart@^1.0.1:
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
 
 strip-ansi@^3.0.0:
   version "3.0.1"
@@ -5819,6 +5922,11 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+util-deprecate@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 util.promisify@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Related to #69 

This PR allows users to supply their own, custom serialisers.

For MongoDB's ObjectIDs, this can be used like the following:

```ts
import SuperJSON from "superjson";
import { ObjectID } from "mongodb";

// this needs to be executed both on client and server
SuperJSON.registerCustom<ObjectID, string>(
  {
    isApplicable: (v): v is ObjectID => v instanceof ObjectID,
    serialize: v => v.toHexString(),
    deserialize: v => new ObjectID(v),
  },
  'objectid'
);

// ...

SuperJSON.serialise({ a: new ObjectID(), ... })
```