### PR TITLE
Add support for serialising Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,18 +202,19 @@ Superjson supports many extra types which JSON does not. You can serialize all t
 
 | type        | supported by standard JSON? | supported by Superjson? |
 | ----------- | --------------------------- | ----------------------- |
-| `string`    | ✅                          | ✅                      |
-| `number`    | ✅                          | ✅                      |
-| `boolean`   | ✅                          | ✅                      |
-| `null`      | ✅                          | ✅                      |
-| `Array`     | ✅                          | ✅                      |
-| `Object`    | ✅                          | ✅                      |
-| `undefined` | ❌                          | ✅                      |
-| `bigint`    | ❌                          | ✅                      |
-| `Date`      | ❌                          | ✅                      |
-| `RegExp`    | ❌                          | ✅                      |
-| `Set`       | ❌                          | ✅                      |
-| `Map`       | ❌                          | ✅                      |
+| `string`    | ✅                           | ✅                       |
+| `number`    | ✅                           | ✅                       |
+| `boolean`   | ✅                           | ✅                       |
+| `null`      | ✅                           | ✅                       |
+| `Array`     | ✅                           | ✅                       |
+| `Object`    | ✅                           | ✅                       |
+| `undefined` | ❌                           | ✅                       |
+| `bigint`    | ❌                           | ✅                       |
+| `Date`      | ❌                           | ✅                       |
+| `RegExp`    | ❌                           | ✅                       |
+| `Set`       | ❌                           | ✅                       |
+| `Map`       | ❌                           | ✅                       |
+| `Error`     | ❌                           | ✅                       |
 
 ## Contributors ✨
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -183,18 +183,18 @@ describe('stringify & parse', () => {
 
     'works for Errors': {
       input: {
-        e: new Error("epic fail")
+        e: new Error('epic fail'),
       },
       output: {
         e: {
-          name: "Error",
-          message: "epic fail",
-          stacktrace: ""
-        }
+          name: 'Error',
+          message: 'epic fail',
+          stacktrace: '',
+        },
       },
       outputAnnotations: {
         values: {
-          e: ["Error"]
+          e: ['Error'],
         },
       },
     },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -181,6 +181,24 @@ describe('stringify & parse', () => {
       },
     },
 
+    'works for Errors': {
+      input: {
+        e: new Error("epic fail")
+      },
+      output: {
+        e: {
+          name: "Error",
+          message: "epic fail",
+          stacktrace: ""
+        }
+      },
+      outputAnnotations: {
+        values: {
+          e: ["Error"]
+        },
+      },
+    },
+
     'works for regex': {
       input: {
         a: /hello/g,

--- a/src/is.ts
+++ b/src/is.ts
@@ -46,6 +46,9 @@ export const isSymbol = (payload: any): payload is symbol =>
 export const isDate = (payload: any): payload is Date =>
   payload instanceof Date && !isNaN(payload.valueOf());
 
+export const isError = (payload: any): payload is Error =>
+  payload instanceof Error;
+
 export const isNaNValue = (payload: any): payload is typeof NaN =>
   typeof payload === 'number' && isNaN(payload);
 


### PR DESCRIPTION
SuperJSON now natively supports serialising the `Error` type.

Closes #74 