### PR TITLE
Remove lodash dep

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,16 +1,5 @@
 module.exports = {
-  plugins: ['es5'],
   rules: {
-    'es5/no-for-of': 'error',
-    'es5/no-generators': 'error',
-    'es5/no-typeof-symbol': 'error',
-    'es5/no-es6-methods': 'error',
-    'es5/no-es6-static-methods': [
-      'error',
-      {
-        exceptMethods: ['Object.assign'],
-      },
-    ],
     "no-restricted-syntax": [
       "error",
       "ForInStatement"

--- a/package.json
+++ b/package.json
@@ -68,8 +68,5 @@
     "tslib": "^2.0.0",
     "typescript": "^3.9.6"
   },
-  "dependencies": {
-    "lodash": "^4.17.20",
-    "lodash-es": "^4.17.15"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@types/lodash": "^4.14.161",
     "@types/mongodb": "^3.5.27",
     "benchmark": "^2.1.4",
-    "eslint-plugin-es5": "^1.5.0",
     "husky": "^4.2.5",
     "mongodb": "^3.6.2",
     "tsdx": "^0.13.2",

--- a/src/custom-transformer-registry.ts
+++ b/src/custom-transformer-registry.ts
@@ -1,5 +1,4 @@
 import { JSONValue } from './types';
-import _ from 'lodash';
 
 export interface CustomTransfomer<I, O extends JSONValue> {
   name: string;
@@ -15,10 +14,10 @@ export const CustomTransformerRegistry = {
     transfomers[transformer.name] = transformer;
   },
 
-  findApplicable<T>(v: T) {
-    return _.find(transfomers, transformer => transformer.isApplicable(v)) as
-      | CustomTransfomer<T, JSONValue>
-      | undefined;
+  findApplicable<T>(v: T): CustomTransfomer<T, JSONValue> | undefined {
+    return Object.values(transfomers).find(transformer =>
+      transformer.isApplicable(v)
+    );
   },
 
   findByName(name: string) {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable es5/no-for-of */
-/* eslint-disable es5/no-es6-methods */
-
 import SuperJSON from './';
 import { JSONValue, SuperJSONValue } from './types';
 import { Annotations } from './annotator';
@@ -721,7 +718,6 @@ describe('stringify & parse', () => {
     class CustomError extends Error {
       constructor(public readonly customProperty: number) {
         super("I'm a custom error");
-        // eslint-disable-next-line es5/no-es6-static-methods
         Object.setPrototypeOf(this, CustomError.prototype);
       }
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "esnext",
     "lib": ["esnext"],
+    "target": "es5",
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "module": "esnext",
     "lib": ["esnext"],
-    "target": "es5",
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3940,11 +3940,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
-  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
-
 lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -3964,11 +3959,6 @@ lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-
-lodash@^4.17.20:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-symbols@^2.2.0:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2280,11 +2280,6 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
-eslint-plugin-es5@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-es5/-/eslint-plugin-es5-1.5.0.tgz#aab19af3d4798f7924bba309bc4f87087280fbba"
-  integrity sha512-Qxmfo7v2B7SGAEURJo0dpBweFf+JU15kSyALfiB2rXWcBuJ96r6X9kFHXFnhdopPHCaHjoQs1xQPUJVbGMb1AA==
-
 eslint-plugin-flowtype@^3.13.0:
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.13.0.tgz#e241ebd39c0ce519345a3f074ec1ebde4cf80f2c"


### PR DESCRIPTION
- Importing lodash for one line of code seems a bit excessive
- Let the TypeScript compiler handle compatability rather than restricting you to write legacy-style code #63