### PR TITLE
allowErrorProps(...) (#91)

### DIFF
--- a/src/error-props.ts
+++ b/src/error-props.ts
@@ -1,0 +1,5 @@
+export const allowedErrorProps: string[] = [];
+
+export const allowErrorProps = (...props: string[]) => {
+  allowedErrorProps.push(...props);
+};

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -741,25 +741,42 @@ describe('stringify & parse', () => {
   });
 });
 
-test('allowErrorProps(...) (#91)', () => {
-  const errorWithAdditionalProps: Error & any = new Error(
-    'I have additional props 😄'
-  );
-  errorWithAdditionalProps.code = 'P2002';
-  errorWithAdditionalProps.meta = '👾';
+describe('allowErrorProps(...) (#91)', () => {
+  it('works with simple prop values', () => {
+    const errorWithAdditionalProps: Error & any = new Error(
+      'I have additional props 😄'
+    );
+    errorWithAdditionalProps.code = 'P2002';
+    errorWithAdditionalProps.meta = '👾';
 
-  // same as allowErrorProps("code", "meta")
-  SuperJSON.allowErrorProps('code');
-  SuperJSON.allowErrorProps('meta');
+    // same as allowErrorProps("code", "meta")
+    SuperJSON.allowErrorProps('code');
+    SuperJSON.allowErrorProps('meta');
 
-  const errorAfterTransition: any = SuperJSON.parse(
-    SuperJSON.stringify(errorWithAdditionalProps)
-  );
+    const errorAfterTransition: any = SuperJSON.parse(
+      SuperJSON.stringify(errorWithAdditionalProps)
+    );
 
-  expect(errorAfterTransition).toBeInstanceOf(Error);
-  expect(errorAfterTransition.message).toEqual('I have additional props 😄');
-  expect(errorAfterTransition.code).toEqual('P2002');
-  expect(errorAfterTransition.meta).toEqual('👾');
+    expect(errorAfterTransition).toBeInstanceOf(Error);
+    expect(errorAfterTransition.message).toEqual('I have additional props 😄');
+    expect(errorAfterTransition.code).toEqual('P2002');
+    expect(errorAfterTransition.meta).toEqual('👾');
+  });
+
+  it.skip('works with complex prop values', () => {
+    const errorWithAdditionalProps: any = new Error();
+    errorWithAdditionalProps.map = new Map();
+
+    SuperJSON.allowErrorProps('map');
+
+    const errorAfterTransition: any = SuperJSON.parse(
+      SuperJSON.stringify(errorWithAdditionalProps)
+    );
+
+    expect(errorAfterTransition.map).toEqual(undefined);
+
+    expect(errorAfterTransition.map).toBeInstanceOf(Map);
+  });
 });
 
 test('regression #83: negative zero', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -741,6 +741,27 @@ describe('stringify & parse', () => {
   });
 });
 
+test('allowErrorProps(...) (#91)', () => {
+  const errorWithAdditionalProps: Error & any = new Error(
+    'I have additional props 😄'
+  );
+  errorWithAdditionalProps.code = 'P2002';
+  errorWithAdditionalProps.meta = '👾';
+
+  // same as allowErrorProps("code", "meta")
+  SuperJSON.allowErrorProps('code');
+  SuperJSON.allowErrorProps('meta');
+
+  const errorAfterTransition: any = SuperJSON.parse(
+    SuperJSON.stringify(errorWithAdditionalProps)
+  );
+
+  expect(errorAfterTransition).toBeInstanceOf(Error);
+  expect(errorAfterTransition.message).toEqual('I have additional props 😄');
+  expect(errorAfterTransition.code).toEqual('P2002');
+  expect(errorAfterTransition.meta).toEqual('👾');
+});
+
 test('regression #83: negative zero', () => {
   const input = -0;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,8 @@ const registerCustom = <I, O extends JSONValue>(
     ...transformer,
   });
 
+const allowErrorProps = (..._props: string[]) => {};
+
 export default {
   stringify,
   parse,
@@ -72,4 +74,5 @@ export default {
   registerClass,
   registerSymbol,
   registerCustom,
+  allowErrorProps
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
   CustomTransfomer,
   CustomTransformerRegistry,
 } from './custom-transformer-registry';
+import { allowErrorProps } from './error-props';
 
 export const serialize = (object: SuperJSONValue): SuperJSONResult => {
   const { getAnnotations, annotator } = makeAnnotator();
@@ -64,8 +65,6 @@ const registerCustom = <I, O extends JSONValue>(
     ...transformer,
   });
 
-const allowErrorProps = (..._props: string[]) => {};
-
 export default {
   stringify,
   parse,
@@ -74,5 +73,5 @@ export default {
   registerClass,
   registerSymbol,
   registerCustom,
-  allowErrorProps
+  allowErrorProps,
 };


### PR DESCRIPTION
This adds `SuperJSON.allowErrorProps(...)`, which can be used to register non-standard error props to be transformed.

See #91