### PR TITLE
fix - don't set meta if empty

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -792,7 +792,7 @@ test('regression #83: negative zero', () => {
   expect(1 / parsed).toBe(-Infinity);
 });
 
-test('regression #X: no undefined', () => {
+test('regression #95: no undefined', () => {
   const input: unknown[] = [];
 
   const out = SuperJSON.serialize(input);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -791,3 +791,14 @@ test('regression #83: negative zero', () => {
 
   expect(1 / parsed).toBe(-Infinity);
 });
+
+test('regression #X: no undefined', () => {
+  const input: unknown[] = [];
+
+  const out = SuperJSON.serialize(input);
+  expect(out).not.toHaveProperty('meta');
+
+  const parsed: number = SuperJSON.deserialize(out);
+
+  expect(parsed).toEqual(input);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,11 +21,13 @@ export const serialize = (object: SuperJSONValue): SuperJSONResult => {
   const output = plainer(object, annotator);
 
   const annotations = getAnnotations();
-
-  return {
+  const res: SuperJSONResult = {
     json: output,
-    meta: isEmptyObject(annotations) ? undefined : annotations,
   };
+  if (!isEmptyObject(annotations)) {
+    res.meta = annotations;
+  }
+  return res;
 };
 
 export const deserialize = <T = unknown>(payload: SuperJSONResult): T => {


### PR DESCRIPTION
causes issues in next if trying to serialize `[]`

(try using `serialize([])` in `getStaticProps()`)