### PR TITLE
Makes sure custom errors are also serialized properly

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,6 +9,19 @@ import { ObjectID } from 'mongodb';
 
 const isNode10 = process.version.indexOf('v10') === 0;
 
+interface ICustomError extends Error {
+  rule: { name: string; lastName: string };
+}
+class CustomError extends Error implements ICustomError {
+  name = 'CustomError';
+  rule: { name: string; lastName: string };
+
+  constructor() {
+    super();
+    this.rule = { name: 'foo', lastName: 'bar' };
+  }
+}
+
 describe('stringify & parse', () => {
   const cases: Record<
     string,
@@ -831,6 +844,21 @@ describe('allowErrorProps(...) (#91)', () => {
     expect(errorAfterTransition.map).toEqual(undefined);
 
     expect(errorAfterTransition.map).toBeInstanceOf(Map);
+  });
+
+  it('custom error works with custom props', () => {
+    SuperJSON.registerClass(CustomError);
+
+    SuperJSON.allowErrorProps('rule');
+    SuperJSON.allowErrorProps('name');
+
+    const errorAfterTransition: any = SuperJSON.parse(
+      SuperJSON.stringify(new CustomError())
+    );
+
+    expect(errorAfterTransition.rule.name).toEqual('foo');
+    expect(errorAfterTransition.rule.lastName).toEqual('bar');
+    expect(errorAfterTransition.name).toEqual('CustomError');
   });
 });
 

--- a/src/is.ts
+++ b/src/is.ts
@@ -47,7 +47,7 @@ export const isDate = (payload: any): payload is Date =>
   payload instanceof Date && !isNaN(payload.valueOf());
 
 export const isError = (payload: any): payload is Error =>
-  payload instanceof Error;
+  payload instanceof Error || payload?.prototype instanceof Error;
 
 export const isNaNValue = (payload: any): payload is typeof NaN =>
   typeof payload === 'number' && isNaN(payload);


### PR DESCRIPTION
This PR makes sure that custom errors get serialized properly.

I have a custom error extending AuthorizationError in blitz and it wasn't being serialized. This change checks if the prototype is an instanceof Error as well