### PR TITLE
refactor: allow individual superjson instances (closes #87)

### DIFF
--- a/src/class-registry.ts
+++ b/src/class-registry.ts
@@ -6,7 +6,7 @@ export interface RegisterOptions {
   allowProps?: string[];
 }
 
-class _ClassRegistry extends Registry<Class> {
+export class ClassRegistry extends Registry<Class> {
   constructor() {
     super(c => c.name);
   }
@@ -29,5 +29,3 @@ class _ClassRegistry extends Registry<Class> {
     return this.classToAllowedProps.get(value);
   }
 }
-
-export const ClassRegistry = new _ClassRegistry();

--- a/src/custom-transformer-registry.ts
+++ b/src/custom-transformer-registry.ts
@@ -8,20 +8,20 @@ export interface CustomTransfomer<I, O extends JSONValue> {
   deserialize: (v: O) => I;
 }
 
-const transfomers: Record<string, CustomTransfomer<any, any>> = {};
+export class CustomTransformerRegistry {
+  private transfomers: Record<string, CustomTransfomer<any, any>> = {};
 
-export const CustomTransformerRegistry = {
   register<I, O extends JSONValue>(transformer: CustomTransfomer<I, O>) {
-    transfomers[transformer.name] = transformer;
-  },
+    this.transfomers[transformer.name] = transformer;
+  }
 
   findApplicable<T>(v: T) {
-    return find(transfomers, transformer => transformer.isApplicable(v)) as
-      | CustomTransfomer<T, JSONValue>
-      | undefined;
-  },
+    return find(this.transfomers, transformer =>
+      transformer.isApplicable(v)
+    ) as CustomTransfomer<T, JSONValue> | undefined;
+  }
 
   findByName(name: string) {
-    return transfomers[name];
-  },
-};
+    return this.transfomers[name];
+  }
+}

--- a/src/error-props.ts
+++ b/src/error-props.ts
@@ -1,5 +1,0 @@
-export const allowedErrorProps: string[] = [];
-
-export const allowErrorProps = (...props: string[]) => {
-  allowedErrorProps.push(...props);
-};

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1076,3 +1076,20 @@ test('prototype pollution - constructor', () => {
 
   expect((Object.prototype as any).x).toBeUndefined();
 });
+
+test('superjson instances are independent of one another', () => {
+  class Car {}
+  const s1 = new SuperJSON();
+  s1.registerClass(Car);
+
+  const s2 = new SuperJSON();
+
+  const value = {
+    car: new Car(),
+  };
+
+  const res1 = s1.serialize(value);
+  expect(res1.meta?.values).toEqual({ car: [['class', 'Car']] });
+  const res2 = s2.serialize(value);
+  expect(res2.json).toEqual(value);
+});

--- a/src/plainer.spec.ts
+++ b/src/plainer.spec.ts
@@ -1,3 +1,4 @@
+import SuperJSON from '.';
 import { walker } from './plainer';
 
 test('walker', () => {
@@ -7,7 +8,8 @@ test('walker', () => {
         a: new Map([[NaN, null]]),
         b: /test/g,
       },
-      new Map()
+      new Map(),
+      new SuperJSON()
     )
   ).toEqual({
     transformedValue: {

--- a/src/symbol-registry.ts
+++ b/src/symbol-registry.ts
@@ -1,3 +1,0 @@
-import { Registry } from './registry';
-
-export const SymbolRegistry = new Registry<Symbol>(s => s.description ?? '');


### PR DESCRIPTION
this allows the creation of individual superjson instances, so there can be multiple different configurations.
it keeps the global instance in place for backwards compatibility, and b/c most users will be fine with one global config.