### PR TITLE
docs: add a section of swc plugin for Next.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ The `getServerSideProps`, `getInitialProps`, and `getStaticProps` data hooks pro
 
 Thankfully, Superjson is a perfect tool to bypass that limitation!
 
-### Next.js (v12.2 or above)
+### Next.js SWC Plugin (experimental, v12.2 or above)
 
-Use [next-superjson-plugin](https://github.com/orionmiz/next-superjson-plugin)
-
+Next.js SWC plugins are [experimental](https://nextjs.org/docs/advanced-features/compiler#swc-plugins-experimental), but promise a significant speedup.
+To use the [SuperJSON SWC plugin](https://github.com/orionmiz/next-superjson-plugin), install it and add it to your `next.config.js`:
 ```sh
 yarn add next-superjson-plugin
 ```

--- a/README.md
+++ b/README.md
@@ -112,6 +112,33 @@ The `getServerSideProps`, `getInitialProps`, and `getStaticProps` data hooks pro
 
 Thankfully, Superjson is a perfect tool to bypass that limitation!
 
+### Next.js (v12.2 or above)
+
+Use [next-superjson-plugin](https://github.com/orionmiz/next-superjson-plugin)
+
+```sh
+yarn add next-superjson-plugin
+```
+
+🚧 Note that swc plugin is still in experimental features.
+
+```js
+// next.config.js
+module.exports = {
+  experimental: {
+    swcPlugins: [
+      [
+        'next-superjson-plugin',
+        {
+          excluded: [],
+        },
+      ],
+    ],
+  },
+}
+```
+
+### Next.js (Older version)
 Install the library with your package manager of choice, e.g.:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ To use the [SuperJSON SWC plugin](https://github.com/orionmiz/next-superjson-plu
 yarn add next-superjson-plugin
 ```
 
-🚧 Note that swc plugin is still in experimental features.
 
 ```js
 // next.config.js

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ module.exports = {
 }
 ```
 
-### Next.js (Older version)
+### Next.js (stable Babel transform)
 Install the library with your package manager of choice, e.g.:
 
 ```sh


### PR DESCRIPTION
Closes: #157 

I made [next-superjson-plugin](https://github.com/orionmiz/next-superjson-plugin) (swc plugin for Next.js)

So added simple instructions to use SuperJSON in the recent version of Next.js
