### PR TITLE
More performant check of isPlainObject

### DIFF
--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -33,6 +33,9 @@ test('Basic true tests', () => {
   expect(isSymbol(Symbol())).toBe(true);
   expect(isTypedArray(new Uint8Array())).toBe(true);
   expect(isURL(new URL('https://example.com'))).toBe(true);
+  expect(isPlainObject({})).toBe(true);
+  // eslint-disable-next-line no-new-object
+  expect(isPlainObject(new Object())).toBe(true);
 });
 
 test('Basic false tests', () => {
@@ -52,6 +55,11 @@ test('Basic false tests', () => {
   expect(isTypedArray([])).toBe(false);
 
   expect(isURL('https://example.com')).toBe(false);
+
+  expect(isPlainObject(null)).toBe(false);
+  expect(isPlainObject([])).toBe(false);
+  expect(isPlainObject(Object.prototype)).toBe(false);
+  expect(isPlainObject(Object.create(Array.prototype))).toBe(false);
 });
 
 test('Primitive tests', () => {

--- a/src/is.ts
+++ b/src/is.ts
@@ -9,9 +9,10 @@ export const isNull = (payload: any): payload is null => payload === null;
 export const isPlainObject = (
   payload: any
 ): payload is { [key: string]: any } => {
-  if (getType(payload) !== 'Object') return false;
-  if (Object.getPrototypeOf(payload) === null) return true;
+  if (typeof payload !== 'object' || payload === null) return false;
   if (payload === Object.prototype) return false;
+  if (Object.getPrototypeOf(payload) === null) return true;
+
   return (
     payload.constructor === Object &&
     Object.getPrototypeOf(payload) === Object.prototype


### PR DESCRIPTION
Before:
```
toy example x 89,736 ops/sec ±0.91% (97 runs sampled)
user graph x 21,863 ops/sec ±0.37% (90 runs sampled)
deep nested x 21.42 ops/sec ±1.54% (40 runs sampled)
```
After:
```
toy example x 94,658 ops/sec ±1.14% (92 runs sampled)
user graph x 23,187 ops/sec ±0.38% (96 runs sampled)
deep nested x 22.04 ops/sec ±1.26% (41 runs sampled)
```

Also, `isPlainObject` would return true on `Object.prototype` which is now fixed and added to the tests.