### PR TITLE
fix: remove "already registered" warning, which triggered too many false positives

### DIFF
--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -16,14 +16,6 @@ test('class registry', () => {
 
   expect(() => registry.register(Car)).not.toThrow();
 
-  const warnSpy = jest.spyOn(console, 'debug');
-
-  registry.register(class Car {});
-  expect(warnSpy).toHaveBeenCalledTimes(1);
-  expect(warnSpy.mock.calls[0][0]).toContain(
-    'Ambiguous class "Car", provide a unique identifier.'
-  );
-
   registry.register(class Car {}, 'car2');
 
   expect(registry.getValue('car2')).not.toBeUndefined();

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -14,15 +14,6 @@ export class Registry<T> {
       identifier = this.generateIdentifier(value);
     }
 
-    if (process.env.NODE_ENV !== 'production') {
-      const alreadyRegistered = this.kv.getByKey(identifier);
-      if (alreadyRegistered && alreadyRegistered !== value) {
-        console.debug(
-          `Ambiguous class "${identifier}", provide a unique identifier.`
-        );
-      }
-    }
-
     this.kv.set(identifier, value);
   }
 


### PR DESCRIPTION
closes https://github.com/blitz-js/superjson/issues/208