### PR TITLE
docs: add reference to next-json in prior art section

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,3 +332,4 @@ Other libraries that aim to solve a similar problem:
 
 - [Serialize JavaScript](https://github.com/yahoo/serialize-javascript) by Eric Ferraiuolo
 - [devalue](https://github.com/Rich-Harris/devalue) by Rich Harris
+- [next-json](https://github.com/iccicci/next-json) by Daniele Ricci

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
 
-## Prior art
+## See also
 
 Other libraries that aim to solve a similar problem:
 


### PR DESCRIPTION
Hi all,

I see there is a mutual support between libraries related to this topic.
I would kinly ask to accept my mutual reference as well.

Thank you