### PR TITLE
Fix compilation error with typescript 5

### DIFF
--- a/src/accessDeep.ts
+++ b/src/accessDeep.ts
@@ -98,7 +98,9 @@ export const setDeep = (
 
   const lastKey = path[path.length - 1];
 
-  if (isArray(parent) || isPlainObject(parent)) {
+  if (isArray(parent)) {
+    parent[+lastKey] = mapper(parent[+lastKey]);
+  } else if (isPlainObject(parent)) {
     parent[lastKey] = mapper(parent[lastKey]);
   }
 


### PR DESCRIPTION
When using typescript 5 in a project using superjson the build fails with the following error:

```text
./node_modules/superjson/src/accessDeep.ts:102:5
Type error: Element implicitly has an 'any' type because expression of type 'string | number' can't be used to index type 'any[] | { [key: string]: any; }'.
  No index signature with a parameter of type 'string' was found on type 'any[] | { [key: string]: any; }'.

  100 | 
  101 |   if (isArray(parent) || isPlainObject(parent)) {
> 102 |     parent[lastKey] = mapper(parent[lastKey]);
      |     ^
  103 |   }
  104 | 
  105 |   if (isSet(parent)) {
```

This change fixes this error.

