### PR TITLE
fix: referential equalities should ignore child nodes

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1141,7 +1141,7 @@ test.only('regression: superjson referential equalities only use the top-most pa
   const res = SuperJSON.serialize(input);
 
   expect(res.json).toEqual(input);
-  
+
   expect(res.meta?.referentialEqualities).toHaveProperty(['a']);
   // saying that a.children is equal to b.children is redundant since its already know that a === b
   expect(res.meta?.referentialEqualities).not.toHaveProperty(['a.children']);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1140,10 +1140,20 @@ test('regression #245: superjson referential equalities only use the top-most pa
   };
   const res = SuperJSON.serialize(input);
 
-  expect(res.json).toEqual(input);
-
   expect(res.meta?.referentialEqualities).toHaveProperty(['a']);
+
   // saying that a.children is equal to b.children is redundant since its already know that a === b
   expect(res.meta?.referentialEqualities).not.toHaveProperty(['a.children']);
-  expect(res.meta).toMatchInlineSnapshot();
+  expect(res.meta).toMatchInlineSnapshot(`
+    Object {
+      "referentialEqualities": Object {
+        "a": Array [
+          "b",
+        ],
+      },
+    }
+  `);
+
+  const parsed = SuperJSON.deserialize(res);
+  expect(parsed).toEqual(input);
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1126,3 +1126,24 @@ test('superjson instances are independent of one another', () => {
   const res2 = s2.serialize(value);
   expect(res2.json).toEqual(value);
 });
+
+test.only('regression: superjson referential equalities only use the top-most parent node', () => {
+  type Node = {
+    children: Node[];
+  };
+  const root: Node = {
+    children: [],
+  };
+  const input = {
+    a: root,
+    b: root,
+  };
+  const res = SuperJSON.serialize(input);
+
+  expect(res.json).toEqual(input);
+  
+  expect(res.meta?.referentialEqualities).toHaveProperty(['a']);
+  // saying that a.children is equal to b.children is redundant since its already know that a === b
+  expect(res.meta?.referentialEqualities).not.toHaveProperty(['a.children']);
+  expect(res.meta).toMatchInlineSnapshot();
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1127,7 +1127,7 @@ test('superjson instances are independent of one another', () => {
   expect(res2.json).toEqual(value);
 });
 
-test.only('regression: superjson referential equalities only use the top-most parent node', () => {
+test('regression #245: superjson referential equalities only use the top-most parent node', () => {
   type Node = {
     children: Node[];
   };

--- a/src/plainer.ts
+++ b/src/plainer.ts
@@ -1,5 +1,3 @@
-import SuperJSON from '.';
-import { getDeep, setDeep } from './accessDeep';
 import {
   isArray,
   isEmptyObject,
@@ -8,14 +6,17 @@ import {
   isPrimitive,
   isSet,
 } from './is';
-import { escapeKey, parsePath, stringifyPath } from './pathstringifier';
+import { escapeKey, stringifyPath } from './pathstringifier';
 import {
-  TypeAnnotation,
   isInstanceOfRegisteredClass,
   transformValue,
+  TypeAnnotation,
   untransformValue,
 } from './transformer';
-import { forEach, includes } from './util';
+import { includes, forEach } from './util';
+import { parsePath } from './pathstringifier';
+import { getDeep, setDeep } from './accessDeep';
+import SuperJSON from '.';
 
 type Tree<T> = InnerNode<T> | Leaf<T>;
 type Leaf<T> = [T];


### PR DESCRIPTION
Closes #245


- Short-circuit result of the walker on already-seen objects
- Will make outputs less noisy
- Should make superjson faster too

---

```sh
yarn test --watch --testNamePattern "#245" --testPathPattern index
```

