### PR TITLE
fix: TypeError: SuperJSON is not a constructor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,8 @@ export default class SuperJSON {
   );
 }
 
+export { SuperJSON };
+
 export const serialize = SuperJSON.serialize;
 export const deserialize = SuperJSON.deserialize;
 


### PR DESCRIPTION
"Fixes" https://github.com/blitz-js/superjson/pull/247#issuecomment-1637631294

```ts
import { SuperJSON } from "superjson"
const superjson = new SuperJSON();
```

now works. default import still broken though