### PR TITLE
bug repro with dedupe=true

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1193,3 +1193,27 @@ test('dedupe=true', () => {
 
   expect(instance.deserialize(output)).toEqual(input);
 });
+
+
+import * as fs from 'fs';
+
+test('dedupe=true testy', () => {
+
+  const content = fs.readFileSync(__dirname + '/non-deduped-cal.json', 'utf-8');
+  const parsed = JSON.parse(content);
+
+  const deserialized = SuperJSON.deserialize(parsed);
+
+  const nondeduped = new SuperJSON({})
+
+  const deduped = new SuperJSON({
+    dedupe: true,
+  });
+
+  const nondedupedOut = nondeduped.deserialize(nondeduped.serialize(deserialized))
+  const dedupedOut = deduped.deserialize(deduped.serialize(deserialized))
+
+
+  expect(dedupedOut).toEqual(nondedupedOut);
+
+})

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1196,7 +1196,7 @@ test('dedupe=true', () => {
   expect(instance.deserialize(output)).toEqual(input);
 });
 
-test.only('dedupe=true testy', () => {
+test('dedupe=true testy', () => {
   const content = fs.readFileSync(__dirname + '/non-deduped-cal.json', 'utf-8');
   const parsed = JSON.parse(content);
 
@@ -1215,4 +1215,45 @@ test.only('dedupe=true testy', () => {
 
   expect(nondedupedOut).toEqual(deserialized);
   expect(dedupedOut).toEqual(deserialized);
+});
+
+test.only('dabbling around with dedupe=true', () => {
+  const deduped = new SuperJSON({
+    dedupe: true,
+  });
+
+  const b = {};
+
+  const obj = {
+    a: { b },
+    b,
+  };
+
+  const { json, meta } = deduped.serialize(obj);
+
+  // Here's the main problem:
+  // we're setting `b` to `null`, because we already saw the object in `a.b`
+  expect(json).toEqual({
+    a: {
+      b: {},
+    },
+    b: null,
+  });
+  // but then, we're also saying that `a.b` is the same as `b` - so we'll end up copying `null` into `a.b`!
+  expect(meta?.referentialEqualities).toEqual({
+    b: ['a.b'],
+  });
+
+  // in this specific case, the correct thing would be to flip around the order of `referentialEqualities`
+  expect(
+    deduped.deserialize({
+      json,
+      meta: { referentialEqualities: { 'a.b': ['b'] } },
+    })
+  ).toEqual(obj);
+
+  // but the current behaviour is definitely wrong:
+  expect(deduped.deserialize({ json, meta })).toEqual(obj);
+
+  // so we need to ensure that `referentialEqualities` always keys by the object that's *not* deduped
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1196,7 +1196,7 @@ test('dedupe=true', () => {
   expect(instance.deserialize(output)).toEqual(input);
 });
 
-test('dedupe=true testy', () => {
+test('dedupe=true on a large complicated schema', () => {
   const content = fs.readFileSync(__dirname + '/non-deduped-cal.json', 'utf-8');
   const parsed = JSON.parse(content);
 
@@ -1215,45 +1215,4 @@ test('dedupe=true testy', () => {
 
   expect(nondedupedOut).toEqual(deserialized);
   expect(dedupedOut).toEqual(deserialized);
-});
-
-test.only('dabbling around with dedupe=true', () => {
-  const deduped = new SuperJSON({
-    dedupe: true,
-  });
-
-  const b = {};
-
-  const obj = {
-    a: { b },
-    b,
-  };
-
-  const { json, meta } = deduped.serialize(obj);
-
-  // Here's the main problem:
-  // we're setting `b` to `null`, because we already saw the object in `a.b`
-  expect(json).toEqual({
-    a: {
-      b: {},
-    },
-    b: null,
-  });
-  // but then, we're also saying that `a.b` is the same as `b` - so we'll end up copying `null` into `a.b`!
-  expect(meta?.referentialEqualities).toEqual({
-    b: ['a.b'],
-  });
-
-  // in this specific case, the correct thing would be to flip around the order of `referentialEqualities`
-  expect(
-    deduped.deserialize({
-      json,
-      meta: { referentialEqualities: { 'a.b': ['b'] } },
-    })
-  ).toEqual(obj);
-
-  // but the current behaviour is definitely wrong:
-  expect(deduped.deserialize({ json, meta })).toEqual(obj);
-
-  // so we need to ensure that `referentialEqualities` always keys by the object that's *not* deduped
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable es5/no-for-of */
 /* eslint-disable es5/no-es6-methods */
 
+import * as fs from 'fs';
+
 import SuperJSON from './';
 import { JSONValue, SuperJSONResult, SuperJSONValue } from './types';
 import {
@@ -1194,26 +1196,23 @@ test('dedupe=true', () => {
   expect(instance.deserialize(output)).toEqual(input);
 });
 
-
-import * as fs from 'fs';
-
-test('dedupe=true testy', () => {
-
+test.only('dedupe=true testy', () => {
   const content = fs.readFileSync(__dirname + '/non-deduped-cal.json', 'utf-8');
   const parsed = JSON.parse(content);
 
   const deserialized = SuperJSON.deserialize(parsed);
 
-  const nondeduped = new SuperJSON({})
+  const nondeduped = new SuperJSON({});
 
   const deduped = new SuperJSON({
     dedupe: true,
   });
 
-  const nondedupedOut = nondeduped.deserialize(nondeduped.serialize(deserialized))
-  const dedupedOut = deduped.deserialize(deduped.serialize(deserialized))
+  const nondedupedOut = nondeduped.deserialize(
+    nondeduped.serialize(deserialized)
+  );
+  const dedupedOut = deduped.deserialize(deduped.serialize(deserialized));
 
-
-  expect(dedupedOut).toEqual(nondedupedOut);
-
-})
+  expect(nondedupedOut).toEqual(deserialized);
+  expect(dedupedOut).toEqual(deserialized);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,8 @@ export default class SuperJSON {
     }
 
     const equalityAnnotations = generateReferentialEqualityAnnotations(
-      identities
+      identities,
+      this.dedupe
     );
     if (equalityAnnotations) {
       res.meta = {


### PR DESCRIPTION
We found a bug with dedupe option.

I'm sorry for this repro, it's awful and huge and bloated. Haven't narrowed it down more, but AFAICT, the results of these should be equal but they aren't.

The problem shows in the diff between non-deduped and deduped; some values stay as `null` after deserializing the deduped one.