### PR TITLE
add "main" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "license": "MIT",
   "type": "module",
   "typings": "dist/index.d.ts",
+  "main": "./dist/index.js",
   "exports": {
     ".": "./dist/index.js"
   },


### PR DESCRIPTION
If I'm not mistaking `"main": "./dist/index.js"` would have no effect when `"exports"` is defined. Right now it's required to resolve the module within a monorepo react-native app.