### PR TITLE
Strip constructor, prototype, and __proto__ properties in the serialize step

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -686,6 +686,23 @@ describe('stringify & parse', () => {
         },
       },
     },
+    'strips constructor, __proto__, and prototype properties': {
+      input: {
+        a: {
+          z: 10,
+          constructor: undefined,
+          __proto__: null,
+          prototype: null,
+        },
+      },
+      output: {
+        a: {
+          z: 10,
+        },
+      },
+      outputAnnotations: undefined,
+      dontExpectEquality: true,
+    },
   };
 
   function deepFreeze(object: any, alreadySeenObjects = new Set()) {

--- a/src/plainer.ts
+++ b/src/plainer.ts
@@ -216,6 +216,14 @@ export const walker = (
   const innerAnnotations: Record<string, Tree<TypeAnnotation>> = {};
 
   forEach(transformed, (value, index) => {
+    if (
+      index === '__proto__' ||
+      index === 'constructor' ||
+      index === 'prototype'
+    ) {
+      return;
+    }
+
     const recursiveResult = walker(
       value,
       identities,


### PR DESCRIPTION
In https://github.com/advisories/GHSA-5888-ffcr-r425, SuperJSON had an issue in which objects with `prototype`, `constructor`, or `__proto__` properties would be reconstituted into potentially dangerous combinations - triggering prototype pollution.

This PR adds to that fix: where there currently is an inability to round-trip an object like `{ constructor: false }` which results in SuperJSON throwing an error, this PR avoids serializing those properties in the first place, preventing a crash when they're deserialized.