### PR TITLE
fix: only throw error on field with annotation

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1059,7 +1059,13 @@ test.each(['__proto__', 'prototype', 'constructor'])(
   forbidden => {
     expect(() => {
       SuperJSON.serialize({
-        [forbidden]: 1,
+        [forbidden]: 1, // doesn't need entry in `meta`, so it's not a risk
+      });
+    }).not.toThrowError();
+
+    expect(() => {
+      SuperJSON.serialize({
+        [forbidden]: new Date(), // needs an entry in `meta`, so it's a risk
       });
     }).toThrowError(/This is a prototype pollution risk/);
   }

--- a/src/plainer.ts
+++ b/src/plainer.ts
@@ -186,7 +186,7 @@ export const walker = (
   }
 
   if (!isDeep(object, superJson)) {
-    const transformed = transformValue(object, superJson);
+    const transformed = transformValue(object, superJson, path);
 
     const result: Result = transformed
       ? {
@@ -209,23 +209,13 @@ export const walker = (
     };
   }
 
-  const transformationResult = transformValue(object, superJson);
+  const transformationResult = transformValue(object, superJson, path);
   const transformed = transformationResult?.value ?? object;
 
   const transformedValue: any = isArray(transformed) ? [] : {};
   const innerAnnotations: Record<string, Tree<TypeAnnotation>> = {};
 
   forEach(transformed, (value, index) => {
-    if (
-      index === '__proto__' ||
-      index === 'constructor' ||
-      index === 'prototype'
-    ) {
-      throw new Error(
-        `Detected property ${index}. This is a prototype pollution risk, please remove it from your object.`
-      );
-    }
-
     const recursiveResult = walker(
       value,
       identities,


### PR DESCRIPTION
This comes out of the discussion in https://github.com/blitz-js/superjson/pull/267. We can narrow down the cases where an error is thrown. It's only necessary if the polluting key results in an annotation, in all other cases there's no risk for prototype pollution.