### PR TITLE
fix: target es2020

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "include": ["src"],
   "exclude": ["**/*.spec.ts", "**/*.test.ts"],
   "compilerOptions": {
+    "target": "ES2020",
     "module": "ES6",
     "moduleResolution": "node",
     "lib": ["esnext"],


### PR DESCRIPTION
Updating the compile target, see https://github.com/blitz-js/superjson/issues/268#issuecomment-1779063042.

@all-contributors please add @peterbud for bug