### PR TITLE
Add src folder to package.json files field

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     ".": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
Hey, it seems you are building with source maps, but you are missing the `src` folder in the `files` field from `package.json`.

Best