### PR TITLE
perf: declare sideEffects

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dist",
     "dist-cjs"
   ],
+  "sideEffects": false,
   "engines": {
     "node": ">=16"
   },


### PR DESCRIPTION
This commit adds `"sideEffects": false` to the `package.json`, which will allow bundlers to eliminate unused exports from this package during tree-shaking.

Webpack docs:
https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
