### PR TITLE
fix: support BigInt64Array and BigUint64Array serialization

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -676,6 +676,30 @@ describe('stringify & parse', () => {
       },
     },
 
+    'works with BigInt typed arrays': {
+      input: {
+        a: new BigInt64Array([1n, 2n, -3n, 9007199254740993n]),
+        b: new BigUint64Array([0n, 18446744073709551615n]),
+      },
+      output: {
+        // bigint isn't valid JSON, so values are stored as strings
+        a: ['1', '2', '-3', '9007199254740993'],
+        b: ['0', '18446744073709551615'],
+      },
+      outputAnnotations: {
+        values: {
+          a: [['typed-array', 'BigInt64Array']],
+          b: [['typed-array', 'BigUint64Array']],
+        },
+      },
+      customExpectations: (value: any) => {
+        expect(value.a).toBeInstanceOf(BigInt64Array);
+        expect([...value.a]).toEqual([1n, 2n, -3n, 9007199254740993n]);
+        expect(value.b).toBeInstanceOf(BigUint64Array);
+        expect([...value.b]).toEqual([0n, 18446744073709551615n]);
+      },
+    },
+
     'works for undefined, issue #48': {
       input: undefined,
       output: null,

--- a/src/is.ts
+++ b/src/is.ts
@@ -79,7 +79,13 @@ export type TypedArrayConstructor =
   | Float32ArrayConstructor
   | Float64ArrayConstructor;
 
-export type TypedArray = InstanceType<TypedArrayConstructor>;
+export type BigIntTypedArrayConstructor =
+  | BigInt64ArrayConstructor
+  | BigUint64ArrayConstructor;
+
+export type TypedArray = InstanceType<
+  TypedArrayConstructor | BigIntTypedArrayConstructor
+>;
 
 export const isTypedArray = (payload: any): payload is TypedArray =>
   ArrayBuffer.isView(payload) && !(payload instanceof DataView);

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -12,6 +12,7 @@ import {
   isError,
   isTypedArray,
   TypedArrayConstructor,
+  BigIntTypedArrayConstructor,
   isURL,
 } from './is.js';
 import { findArr } from './util.js';
@@ -221,19 +222,41 @@ const constructorToName = [
   return obj;
 }, {});
 
+// BigInt-backed typed arrays hold `bigint` elements, which JSON.stringify
+// cannot represent. They're serialized/deserialized as strings instead.
+const bigIntConstructorToName: Record<string, BigIntTypedArrayConstructor> = {};
+if (typeof BigInt64Array !== 'undefined') {
+  bigIntConstructorToName[BigInt64Array.name] = BigInt64Array;
+}
+if (typeof BigUint64Array !== 'undefined') {
+  bigIntConstructorToName[BigUint64Array.name] = BigUint64Array;
+}
+
 const typedArrayRule = compositeTransformation(
   isTypedArray,
   v => ['typed-array', v.constructor.name],
-  v => [...v].map(n => {
-    // Handle special float values that JSON.stringify converts to null
-    if (typeof n === 'number') {
-      if (Number.isNaN(n)) return 'NaN';
-      if (n === Infinity) return 'Infinity';
-      if (n === -Infinity) return '-Infinity';
-    }
-    return n;
-  }),
+  v =>
+    [...v].map(n => {
+      // bigint values (from BigInt64Array / BigUint64Array) are not valid JSON,
+      // so they're stored as strings.
+      if (typeof n === 'bigint') {
+        return n.toString();
+      }
+      // Handle special float values that JSON.stringify converts to null
+      if (typeof n === 'number') {
+        if (Number.isNaN(n)) return 'NaN';
+        if (n === Infinity) return 'Infinity';
+        if (n === -Infinity) return '-Infinity';
+      }
+      return n;
+    }),
   (v, a) => {
+    const bigIntCtor = bigIntConstructorToName[a[1]];
+    if (bigIntCtor) {
+      const values = v.map((n: string | number | bigint): bigint => BigInt(n));
+      return new bigIntCtor(values);
+    }
+
     const ctor = constructorToName[a[1]];
 
     if (!ctor) {


### PR DESCRIPTION
## Problem

`BigInt64Array` and `BigUint64Array` are detected as typed arrays by `isTypedArray` (they pass `ArrayBuffer.isView` and aren't `DataView`), so superjson annotates them as `['typed-array', 'BigInt64Array']` and tries to round-trip them. But the round-trip is broken in two ways:

- **`serialize`/`stringify` throws** — the transform produces an array of raw `bigint` elements, which `JSON.stringify` cannot represent: `TypeError: Do not know how to serialize a BigInt`.
- **`deserialize` throws** — `constructorToName` only lists the numeric typed arrays, so the BigInt variants hit `Error: Trying to deserialize unknown typed array`.

Reproduction on `main`:

```ts
import superjson from 'superjson';

superjson.stringify(new BigInt64Array([1n, 2n, 3n]));
// TypeError: Do not know how to serialize a BigInt

superjson.deserialize(superjson.serialize(new BigUint64Array([1n])));
// Error: Trying to deserialize unknown typed array
```

## Fix

`bigint` isn't valid JSON, so (mirroring how the existing code stores `NaN`/`Infinity` as strings) BigInt typed-array elements are serialized as decimal strings and parsed back with `BigInt(...)` on deserialization. A small `bigIntConstructorToName` lookup maps the two BigInt typed-array constructors back to their classes.

The constructor registration is guarded with `typeof BigInt64Array !== 'undefined'`, consistent with the existing BigInt-polyfill defensiveness in `transformer.ts`, so environments without these globals are unaffected.

Serialized form (now JSON-safe):

```json
{ "json": ["1", "2", "3"], "meta": { "values": [["typed-array", "BigInt64Array"]], "v": 1 } }
```

## Tests

Added a `works with BigInt typed arrays` case to the `stringify & parse` fixtures (which round-trips through `JSON.parse(JSON.stringify(...))`, so it also covers the `stringify` path). It verifies the serialized shape, the type annotations, that values revive to the correct typed-array class, and exact element equality — including values that would lose precision as `number` (`9007199254740993n`) and `BigUint64Array`'s max (`18446744073709551615n`).

The new test fails on `main` (`Do not know how to serialize a BigInt`) and passes with this change. Full suite (`pnpm test`) and `tsc` build both pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes broken serialization of `BigInt64Array` and `BigUint64Array` by converting their `bigint` elements to/from decimal strings during JSON encoding — mirroring the existing `NaN`/`Infinity` string strategy for numeric typed arrays.

- **`src/transformer.ts`**: A `bigIntConstructorToName` lookup (guarded by `typeof BigInt64Array !== 'undefined'`) maps constructor names to their classes; the serialize path calls `n.toString()` for bigint elements, and the deserialize path calls `BigInt(n)` and reconstructs the correct typed-array subclass.
- **`src/is.ts`**: Adds `BigIntTypedArrayConstructor` and widens `TypedArray` to include `BigInt64Array`/`BigUint64Array` instances, keeping the type definitions consistent with the new runtime support.
- **`src/index.test.ts`**: Adds a fixture that round-trips both array types, including a value that would lose precision as a `number` (`9007199254740993n`) and `BigUint64Array`'s maximum (`18446744073709551615n`).

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix is narrowly scoped to the two BigInt typed-array classes and does not touch existing numeric typed-array paths.

The serialization and deserialization logic is correct and follows the established NaN/Infinity string pattern. The `bigIntConstructorToName` lookup is properly guarded for environments without BigInt typed arrays. Tests cover precision-critical values and the full round-trip through JSON.stringify/parse.

The deserialization branch in `src/transformer.ts` (lines 254–258) is the most sensitive change — worth a quick read to confirm the `BigInt(n)` call aligns with all expected input shapes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/is.ts | Adds `BigIntTypedArrayConstructor` type and expands `TypedArray` to include BigInt64Array and BigUint64Array instances — clean, minimal type-level change. |
| src/transformer.ts | Adds `bigIntConstructorToName` lookup and updates `typedArrayRule` to serialize bigint elements as strings and deserialize them back with `BigInt(n)`. Logic is sound; naming follows existing convention. |
| src/index.test.ts | Adds a round-trip test case for both BigInt64Array and BigUint64Array covering precision-exceeding values (9007199254740993n) and BigUint64 max (18446744073709551615n). |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant typedArrayRule
    participant JSON

    Note over Caller,JSON: Serialize BigInt64Array([1n, 2n, -3n])
    Caller->>typedArrayRule: transform(BigInt64Array)
    typedArrayRule->>typedArrayRule: "[...v].map(n => n.toString()) for bigint"
    typedArrayRule-->>Caller: ["1", "2", "-3"] + annotation ["typed-array", "BigInt64Array"]
    Caller->>JSON: JSON.stringify(["1","2","-3"])
    JSON-->>Caller: valid JSON

    Note over Caller,JSON: Deserialize
    Caller->>JSON: JSON.parse(...)
    JSON-->>Caller: ["1", "2", "-3"]
    Caller->>typedArrayRule: untransform(["1","2","-3"], ["typed-array","BigInt64Array"])
    typedArrayRule->>typedArrayRule: "bigIntConstructorToName["BigInt64Array"] -> BigInt64Array"
    typedArrayRule->>typedArrayRule: "v.map(n => BigInt(n)) -> [1n, 2n, -3n]"
    typedArrayRule->>typedArrayRule: new BigInt64Array([1n, 2n, -3n])
    typedArrayRule-->>Caller: BigInt64Array([1n, 2n, -3n])
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: support BigInt64Array and BigUint64..."](https://github.com/flightcontrolhq/superjson/commit/64c02259d1b6026cc72623b073291938fc56cd99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37595643)</sub>

<!-- /greptile_comment -->