### PR TITLE
fix: don't synthesize a cause on Errors that never had one

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1033,6 +1033,29 @@ describe('allowErrorProps(...) (#91)', () => {
   });
 });
 
+describe('Error without a cause', () => {
+  it('does not synthesize an own cause property on the round-trip', () => {
+    const original = new Error('no cause here');
+    expect(Object.hasOwn(original, 'cause')).toBe(false);
+
+    const roundTripped: any = SuperJSON.parse(SuperJSON.stringify(original));
+
+    expect(roundTripped).toBeInstanceOf(Error);
+    expect(roundTripped.message).toBe('no cause here');
+    expect(Object.hasOwn(roundTripped, 'cause')).toBe(false);
+  });
+
+  it('preserves an explicit cause', () => {
+    const original = new Error('outer', { cause: 'inner reason' });
+    expect(Object.hasOwn(original, 'cause')).toBe(true);
+
+    const roundTripped: any = SuperJSON.parse(SuperJSON.stringify(original));
+
+    expect(Object.hasOwn(roundTripped, 'cause')).toBe(true);
+    expect(roundTripped.cause).toBe('inner reason');
+  });
+});
+
 test('regression #83: negative zero', () => {
   const input = -0;
 

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -98,7 +98,10 @@ const simpleRules = [
       return baseError;
     },
     (v, superJson) => {
-      const e = new Error(v.message, { cause: v.cause });
+      const e =
+        'cause' in v
+          ? new Error(v.message, { cause: v.cause })
+          : new Error(v.message);
       e.name = v.name;
       e.stack = v.stack;
 


### PR DESCRIPTION
## Description

A round trip through SuperJSON adds an own `cause` property to any `Error` that didn't have one.

The serializer only emits a `cause` when the source error actually has the property (`transformer.ts`):

```ts
if ('cause' in v) {
  baseError.cause = v.cause;
}
```

…but the deserializer passes the options object unconditionally:

```ts
const e = new Error(v.message, { cause: v.cause });
```

Per the spec, the `Error` constructor installs an own `cause` property whenever the options object *has* a `cause` key (`InstallErrorCause`), and `{ cause: undefined }` does have that key. So an error serialized without a cause is revived with an own `cause: undefined` property it never had:

```ts
const e = new Error('boom');
Object.hasOwn(e, 'cause'); // false

const r = SuperJSON.deserialize(SuperJSON.serialize(e));
Object.hasOwn(r, 'cause'); // true  ← synthesized
r.cause;                   // undefined
```

Because the revived error now owns a `cause`, re-serializing it emits one too, so `stringify` is not idempotent across a round trip. This matters wherever errors are round-tripped (e.g. tRPC), and it changes `Object.keys(err)` / spread behaviour.

The fix mirrors the serializer's `'cause' in v` guard so the options object is only passed when a cause was actually serialized — preserving real causes (including an explicit `cause: undefined`) and leaving cause-less errors untouched.

Closes the round-trip asymmetry; no public API change.

## Test plan

### Before

- `new Error('x')` round-tripped to an error with an own `cause: undefined` property; `Object.hasOwn(roundTripped, 'cause')` was `true`.

### After

- A cause-less error round-trips without gaining a `cause` (`Object.hasOwn` stays `false`).
- An error with an explicit cause still round-trips with the cause intact.

Added two cases under `describe('Error without a cause', …)` in `src/index.test.ts` (the first fails on `main`, both pass after the fix). Full suite green (`npm test`, 85 passing).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an idempotency bug where round-tripping a cause-less `Error` through SuperJSON synthesized a spurious own `cause: undefined` property that was never on the original error. The root cause was that the deserializer unconditionally passed `{ cause: v.cause }` to the `Error` constructor, and per spec `InstallErrorCause` installs the property whenever the options object contains a `cause` key — even if the value is `undefined`.

- `src/transformer.ts`: adds a `'cause' in v` guard to the deserializer, exactly mirroring the existing guard in the serializer, so the options object is only passed when the serialized payload actually contains a `cause` key.
- `src/index.test.ts`: adds two regression tests — one verifying that a cause-less error gains no own `cause` after a round-trip, and one verifying that an error with an explicit cause still round-trips correctly.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is minimal, well-targeted, and fully covered by new tests.

The fix is a one-liner guard that mirrors an identical guard already present in the serializer. Both changed files are small, the logic is straightforward, and the new tests confirm the corrected and previously-correct behaviors. The only open question is around `cause: undefined` not being round-trippable through JSON, but that is a pre-existing, inherent JSON limitation rather than anything introduced here.

No files require special attention; both changes are self-contained and easy to verify.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/transformer.ts | Added `'cause' in v` guard to the Error deserializer, mirroring the existing guard in the serializer to prevent spurious own-cause synthesis on round-trip. |
| src/index.test.ts | Adds two regression tests covering the no-cause and explicit-cause round-trip cases; the first test fails on main and passes after the fix. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App
    participant Serializer as transformer.ts (serialize)
    participant JSON
    participant Deserializer as transformer.ts (deserialize)

    App->>Serializer: Error("msg") [no cause]
    Serializer->>Serializer: 'cause' in v? → false, omit cause
    Serializer->>JSON: "{ name, message } (no cause key)"
    JSON-->>Deserializer: "{ name, message }"
    Deserializer->>Deserializer: 'cause' in v? → false
    Deserializer-->>App: new Error(v.message) ✅ no own cause

    App->>Serializer: "Error("msg", { cause: "x" })"
    Serializer->>Serializer: 'cause' in v? → true, emit cause
    Serializer->>JSON: "{ name, message, cause: "x" }"
    JSON-->>Deserializer: "{ name, message, cause: "x" }"
    Deserializer->>Deserializer: 'cause' in v? → true
    Deserializer-->>App: "new Error(v.message, { cause: "x" }) ✅ cause preserved"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App
    participant Serializer as transformer.ts (serialize)
    participant JSON
    participant Deserializer as transformer.ts (deserialize)

    App->>Serializer: Error("msg") [no cause]
    Serializer->>Serializer: 'cause' in v? → false, omit cause
    Serializer->>JSON: "{ name, message } (no cause key)"
    JSON-->>Deserializer: "{ name, message }"
    Deserializer->>Deserializer: 'cause' in v? → false
    Deserializer-->>App: new Error(v.message) ✅ no own cause

    App->>Serializer: "Error("msg", { cause: "x" })"
    Serializer->>Serializer: 'cause' in v? → true, emit cause
    Serializer->>JSON: "{ name, message, cause: "x" }"
    JSON-->>Deserializer: "{ name, message, cause: "x" }"
    Deserializer->>Deserializer: 'cause' in v? → true
    Deserializer-->>App: "new Error(v.message, { cause: "x" }) ✅ cause preserved"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/index.test.ts:1046-1056
**Missing test for `cause: undefined` round-trip**

The PR description states the fix "preserves real causes (including an explicit `cause: undefined`)," but this case isn't tested — and it actually cannot survive a round-trip. `JSON.stringify` silently drops object properties whose value is `undefined`, so the `cause` key is lost in the serialized payload. The deserializer sees no `cause` key and produces an error without an own `cause`. A test case for `new Error('msg', { cause: undefined })` would document this limitation and prevent future confusion about whether the behavior is intentional.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: don&#39;t synthesize a cause on Errors ..."](https://github.com/flightcontrolhq/superjson/commit/22b5e26f3ba48bb03e9416b649aa25e6b86cced3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38123384)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->